### PR TITLE
fix: incorrect date rendering due to UTC parsing (Timezone Fix)

### DIFF
--- a/src/render/matrixDataGenerator.ts
+++ b/src/render/matrixDataGenerator.ts
@@ -1,6 +1,7 @@
-import { diffDays } from "../util/dateUtils";
+import { diffDays, parseDate } from "../util/dateUtils";
 import { Contribution, ContributionCellData } from "../types";
 import { DateTime } from "luxon";
+
 
 export function generateByData(data: Contribution[]) {
 	if (!data || data.length === 0) {
@@ -8,18 +9,13 @@ export function generateByData(data: Contribution[]) {
 	}
 
 	const dateData = data.map((item) => {
-		if (item.date instanceof Date) {
-			return {
-				...item,
-				timestamp: item.date.getTime(),
-			};
-		} else {
-			return {
-				...item,
-				date: new Date(item.date),
-				timestamp: new Date(item.date).getTime(),
-			};
-		}
+		const localDate = parseDate(item.date);
+		
+		return {
+			...item,
+			date: localDate,
+			timestamp: localDate.getTime(),
+		};
 	});
 
 	const sortedData = dateData.sort((a, b) => b.timestamp - a.timestamp);

--- a/src/util/dateUtils.ts
+++ b/src/util/dateUtils.ts
@@ -2,6 +2,13 @@ import { DateTime } from "luxon";
 
 export function parseDate(date: string | Date) {
 	if (typeof date === "string") {
+		// Check whether it is pure date format (yyyy-MM-dd)
+		// if so, parse it to local timezone
+		if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+			const [y, m, d] = date.split('-').map(Number);
+			// new Date(y, m, d) create 00:00:00 in local timezone
+			return new Date(y, m - 1, d);
+		}
 		return new Date(date);
 	} else {
 		return date;


### PR DESCRIPTION
## Problem
When parsing date strings in `yyyy-MM-dd` format (e.g., "2026-01-01"), `new Date(string)` treats them as UTC 00:00:00 by default. 

For users in timezones west of UTC (e.g., UTC-5 EST), this converts to the previous day (e.g., "2025-12-31 19:00:00"), causing the contribution cell to render on the wrong day (Wednesday instead of Thursday).

## Solution
I modified `dateUtils.ts` and `matrixDataGenerator.ts` to strictly parse `yyyy-MM-dd` strings using the `new Date(year, monthIndex, day)` constructor. This ensures the date is created at 00:00:00 in the **local system timezone**, preventing any day shifts regardless of the user's location.

## Changes
- Updated `parseDate` in `src/utils/dateUtils.ts` to manually parse ISO date strings.
- Updated `generateByData` in `src/render/matrixDataGenerator.ts` to use the robust `parseDate` function.

## Verification
Tested locally in an environment with UTC-5 timezone. The date "2026-01-01" now correctly maps to Thursday instead of Wednesday.

ps:也是第一次因为感受到时差带来的bug，小修了一下，感谢作者大大的插件！