### PR TITLE
Fix day‑1 timezone bug and corresponding heatmap rendering alignment

### DIFF
--- a/src/render/gitStyleTrackGraphRender.ts
+++ b/src/render/gitStyleTrackGraphRender.ts
@@ -48,8 +48,7 @@ export class GitStyleTrackGraphRender extends BaseGraphRender {
 
 		// fill HOLE cell at the left most column if start date is not ${startOfWeek}
 		if (contributionData.length > 0) {
-			const from = new Date(contributionData[0].date);
-			const weekDayOfFromDate = from.getDay();
+			const weekDayOfFromDate = contributionData[0].weekDay;
 			const firstHoleCount = distanceBeforeTheStartOfWeek(
 				graphConfig.startOfWeek || 0,
 				weekDayOfFromDate

--- a/src/render/graphRender.ts
+++ b/src/render/graphRender.ts
@@ -242,6 +242,12 @@ export abstract class BaseGraphRender implements GraphRender {
 	) {
 		if (graphConfig.cellStyle) {
 			Object.assign(cellEl.style, graphConfig.cellStyle);
+			if (graphConfig.cellStyle.minWidth) {
+				cellEl.style.width = graphConfig.cellStyle.minWidth;
+			}
+			if (graphConfig.cellStyle.minHeight) {
+				cellEl.style.height = graphConfig.cellStyle.minHeight;
+			}
 		}
 	}
 
@@ -257,6 +263,12 @@ export abstract class BaseGraphRender implements GraphRender {
 				return acc;
 			}, {});
 			Object.assign(cellEl.style, partialStyle);
+			if (props.includes("minWidth") && graphConfig.cellStyle.minWidth) {
+				cellEl.style.width = graphConfig.cellStyle.minWidth;
+			}
+			if (props.includes("minHeight") && graphConfig.cellStyle.minHeight) {
+				cellEl.style.height = graphConfig.cellStyle.minHeight;
+			}
 		}
 	}
 

--- a/src/render/matrixDataGenerator.ts
+++ b/src/render/matrixDataGenerator.ts
@@ -1,6 +1,7 @@
-import { diffDays } from "../util/dateUtils";
+import { diffDays, parseDate } from "../util/dateUtils";
 import { Contribution, ContributionCellData } from "../types";
 import { DateTime } from "luxon";
+
 
 export function generateByData(data: Contribution[]) {
 	if (!data || data.length === 0) {
@@ -8,18 +9,13 @@ export function generateByData(data: Contribution[]) {
 	}
 
 	const dateData = data.map((item) => {
-		if (item.date instanceof Date) {
-			return {
-				...item,
-				timestamp: item.date.getTime(),
-			};
-		} else {
-			return {
-				...item,
-				date: new Date(item.date),
-				timestamp: new Date(item.date).getTime(),
-			};
-		}
+		const localDate = parseDate(item.date);
+		
+		return {
+			...item,
+			date: localDate,
+			timestamp: localDate.getTime(),
+		};
 	});
 
 	const sortedData = dateData.sort((a, b) => b.timestamp - a.timestamp);

--- a/src/render/monthTrackGraphRender.ts
+++ b/src/render/monthTrackGraphRender.ts
@@ -108,8 +108,7 @@ export class MonthTrackGraphRender extends BaseGraphRender {
 
 			// fill hole at start month, if start month date is not 1
 			if (i == 0) {
-				const startDate = new Date(contributionItem.date).getDate();
-				const fillMax = startDate - 1;
+				const fillMax = contributionItem.monthDate - 1;
 				for (let j = 0; j < fillMax; j++) {
 					const cellEl = document.createElement("div");
 					cellEl.className = "cell";

--- a/src/util/dateUtils.ts
+++ b/src/util/dateUtils.ts
@@ -2,6 +2,13 @@ import { DateTime } from "luxon";
 
 export function parseDate(date: string | Date) {
 	if (typeof date === "string") {
+		// Check whether it is pure date format (yyyy-MM-dd)
+		// if so, parse it to local timezone
+		if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+			const [y, m, d] = date.split('-').map(Number);
+			// new Date(y, m, d) create 00:00:00 in local timezone
+			return new Date(y, m - 1, d);
+		}
 		return new Date(date);
 	} else {
 		return date;


### PR DESCRIPTION
## Summary
This PR resolves the day‑1 issue in the contribution graph and then fixes the remaining rendering alignment problems in the weekly/monthly/yearly views.

## Approach
1) Found the day‑1 bug and fixed it at the utility layer.
2) After that, rendering was still misaligned, so a second round of fixes targeted the render logic.

## Root cause
- Date inputs (especially `YYYY‑MM‑DD` strings and UTC‑midnight values) were interpreted in local time and could shift to the previous day.
- Some render paths re‑parsed ISO strings with `new Date(...)`, which re‑introduced offsets and broke alignment.

## Fixes
  - `parseDate` now treats pure `YYYY‑MM‑DD` as local midnight using `new Date(y, m-1, d)`.
  - Other strings still use `new Date(...)`.
  - `generateByData` uses `parseDate` to normalize incoming data.
  - Fix the rendering part accordingly.

## Files touched
- `src/util/dateUtils.ts`
- `src/render/matrixDataGenerator.ts`
- `src/render/monthTrackGraphRender.ts`
- `src/render/gitStyleTrackGraphRender.ts`
- `src/render/graphRender.ts`

## Testing
- Manual verification on local machine:
  - Weekly, monthly, and yearly views all render correctly with no day‑1 shift.
